### PR TITLE
Making the vCenter password var sensitive

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -86,7 +86,7 @@ resource "aci_rest_managed" "vmmUsrAccP" {
   content = {
     name = each.value.name
     usr  = each.value.username
-    pwd  = each.value.password
+    pwd  = sensitive(each.value.password)
   }
 
   lifecycle {


### PR DESCRIPTION
In the variables.tf file, I can't see a straightforward way to make only the password sensitive from the vCenter credentials, because the password is part of an object variable:

```
variable "credential_policies" {
  description = "List of vCenter credentials."
  type = list(object({
    name     = string
    username = string
    password = string
  }))
  default = []
```

See:
https://discuss.hashicorp.com/t/is-it-possible-to-mark-an-attribute-of-an-object-as-sensitive/24649/2

Instead I used sensitive() around the password in main.tf.

I tested this and the password was ommitted from the terraform plan output:

![image](https://user-images.githubusercontent.com/56433849/218733061-4a5ded60-601a-4644-a064-41564075e8ed.png)


